### PR TITLE
Resolve creation of table from base/initialization error

### DIFF
--- a/export.py
+++ b/export.py
@@ -1079,12 +1079,12 @@ def initCursor(mydb):
 
 # Deletes the current content within the Course table
 def dropCourseTable(db, cursor):
-    cursor.execute("DROP TABLE courses")
+    cursor.execute("DROP TABLE if EXISTS courses")
     db.commit()
 
 # Deletes the current content within the Assignments table
 def dropAssignmentTable(db, cursor):
-    cursor.execute("DROP TABLE assignments")
+    cursor.execute("DROP TABLE if EXISTS assignments")
     db.commit()
 
 # Create a new course table


### PR DESCRIPTION
This is an error that occurs if you have never created a version of the assignments or courses table in MySQL. Currently the code attempts to run a delete command in SQL to remove any existing tables to not encounter an error in the next step when it tries to create the assignments and courses table. The current approach to tackling this issue is to use the SQL if exists
function to check if the table exists and then wipe it if it does. This will prevent any data duplication and avoid errors if the user has never generated the tables.